### PR TITLE
Custom Header Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,10 @@ can also be
 overtime show utc-5 utc+7
 ```
 
+Finally, if you'd like to alias the headers you can optionally use `@` on any of the zones/offsets:
+
+```
+overtime show utc-8@vancity America/Halifax@halifornia Asia/Tokyo
+```
+
 Made with ☕ in 🇨🇦

--- a/index.js
+++ b/index.js
@@ -7,18 +7,32 @@ const assert = require('assert')
 const { DateTime } = require('luxon')
 const chalk = require('chalk')
 
+
 const vorpal = require('vorpal')()
 
 const NIGHT_TIME_START = 20
 const NIGHT_TIME_END = 9
 
+const ALIAS_SPLITTER = '@';
+
 vorpal.command('show [regions...]', 'Generates time overlap table')
   .alias('table')
   .action(function (args, cb) {
+
     // TODO: BETTER VALIDATION
     assert(args.regions.length > 0)
+
+    const pairs = args.regions.map((region) => {
+
+      return (region.includes(ALIAS_SPLITTER)) ? region.split(ALIAS_SPLITTER) : [region, region]
+
+    });
+
+    const regions = pairs.map(pair => pair[0]);
+    const aliases = pairs.map(pair => pair[1]);
+
     const table = new Table({
-      head: args.regions
+      head: aliases
     })
 
     // TODO: Pivot from primary
@@ -41,7 +55,7 @@ vorpal.command('show [regions...]', 'Generates time overlap table')
 
     for (let hour = 0; hour < 24; hour++) {
       const row = []
-      args.regions.forEach(region => {
+      regions.forEach(region => {
         row.push(formatTime(getRegionsTime(region).plus({
           hours: hour
         }).set({


### PR DESCRIPTION
Provides ability to alias the tz or offset using a special separation character (`@`).

![image](https://user-images.githubusercontent.com/757192/33524040-dc881550-d7c9-11e7-85a4-67005679136c.png)


Fully optional. If the alias is not found, the header will fall back to specified tz or offset.